### PR TITLE
Create services in Kubernetes

### DIFF
--- a/mysql-service.yaml
+++ b/mysql-service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql-service
+spec:
+  selector:
+    app: mysql
+  ports:
+  - port: 3306
+    targetPort: 3306

--- a/turkle-service.yaml
+++ b/turkle-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: turkle-deployment
+spec:
+  type: NodePort
+  selector:
+    app: turkle
+  ports:
+  - port: 8080
+    targetPort: 8080
+    nodePort: 30000


### PR DESCRIPTION
This PR creates two services that will expose MySQL and Turkle to the Kubernetes cluster. Without this, there is no cross pod communication that in a traditional kubernetes setup (testing with Kubernetes on Docker Desktop).

The turkle service also uses NodePort in order to expose the service on the kubernetes node main IP address.

Once these have been applied, the website should be available on http://localhost:30000